### PR TITLE
fix vulnerability in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "fs-extra": "5.0.0",
     "graphql-import": "0.4.5",
     "graphql-static-binding": "0.9.3",
-    "lodash": "4.17.5"
+    "lodash": "4.17.11"
   }
 }


### PR DESCRIPTION
Prototype Pollution
Vulnerable module: lodash
Introduced through: graphql-cli@3.0.12
Detailed paths
Introduced through: @spherehq/database@0.13.1 › graphql-cli@3.0.12 › graphql-cli-prepare@1.4.19 › lodash@4.17.5
Remediation: No remediation path available.
Vulnerable Functions
lodash.safeGet
  
Overview
lodash is a modern JavaScript utility library delivering modularity, performance, & extras.

Affected versions of this package are vulnerable to Prototype Pollution. The functions merge, mergeWith, and defaultsDeep could be tricked into adding or modifying properties of Object.prototype. This is due to an incomplete fix to CVE-2018-3721.